### PR TITLE
Add serde by default

### DIFF
--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/gabhijit/hampi.git"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 include = ["src/**/*.rs", "README.md", "ARChITECTURE.md", "Cargo.toml", "LICENSE", "LICENSE-MIT", "LICENSE-Apache2"]
+default-run = "hampi-rs-asn1c"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/asn-compiler/src/generator/int.rs
+++ b/asn-compiler/src/generator/int.rs
@@ -34,12 +34,6 @@ pub enum Derive {
     /// Generate 'Clone' code for the generated structures.
     Clone,
 
-    /// Generate 'serde::Serialize' code for the generated structures.
-    Serialize,
-
-    /// Generate 'serde::Deserialize' code for the generated structures.
-    Deserialize,
-
     /// Generate `Eq` code for the generated structures.
     Eq,
 
@@ -72,8 +66,6 @@ lazy_static! {
         let mut m = HashMap::new();
         m.insert(Derive::Debug, "Debug".to_string());
         m.insert(Derive::Clone, "Clone".to_string());
-        m.insert(Derive::Serialize, "serde::Serialize".to_string());
-        m.insert(Derive::Deserialize, "serde::Deserialize".to_string());
         m.insert(Derive::Eq, "Eq".to_string());
         m.insert(Derive::PartialEq, "PartialEq".to_string());
         m
@@ -244,7 +236,9 @@ impl Generator {
         let token_string = tokens.join(",");
 
         let derive_token_string = format!("#[derive({})]\n", token_string);
-        let derive_token_stream: TokenStream = derive_token_string.parse().unwrap();
+        let auto_serde = "#[cfg_attr(feature = \"serde_support\", derive(serde::Serialize, serde::Deserialize))]";
+        let derive_with_serde = format!("{}\n{}", derive_token_string, auto_serde);
+        let derive_token_stream: TokenStream = derive_with_serde.parse().unwrap();
         derive_token_stream
     }
 }


### PR DESCRIPTION
Hello,


With this PR, serde derives are added  by default.

The user can then just specify that he is using the feature `serde_support` to use serde

You can test with

```bash
cargo run -- --codec  uper --module code.rs -- examples/specs/rrc/rrc.asn
# check code.rs
```