### PR TITLE
Workaround #133: Ignore decode of seq extension additions

### DIFF
--- a/asn-compiler/src/parser/asn/types/int.rs
+++ b/asn-compiler/src/parser/asn/types/int.rs
@@ -38,6 +38,7 @@ pub(crate) fn parse_type(tokens: &[Token]) -> Result<(Asn1Type, usize)> {
     }
 
     // Now: Parse The Type definition.
+    log::trace!("Current token: {:#?}", &tokens[consumed]);
     let token = &tokens[consumed];
     let typestr = token.text.as_str();
     let (kind, kind_consumed) = match typestr {

--- a/codecs/src/lib.rs
+++ b/codecs/src/lib.rs
@@ -17,3 +17,7 @@ pub use per::aper;
 
 #[doc(inline)]
 pub use per::uper;
+
+// For now making this public, eventually when we have a proper sequence extensions support, this
+// will not be required anyways.
+pub use per::common::decode::decode_sequence_extensions_skip_bits;

--- a/codecs/src/per/mod.rs
+++ b/codecs/src/per/mod.rs
@@ -7,7 +7,7 @@ pub mod aper;
 
 pub mod uper;
 
-mod common;
+pub(crate) mod common;
 
 pub use error::Error as PerCodecError;
 pub use error::ErrorCause as PerCodecErrorCause;

--- a/codecs_derive/tests/09-open.rs
+++ b/codecs_derive/tests/09-open.rs
@@ -32,7 +32,7 @@ pub struct LPPa_PDU(Vec<u8>);
 pub struct ENB_UE_S1AP_ID(u32);
 
 #[derive(Debug, AperCodec, UperCodec, Eq, PartialEq)]
-#[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
+#[asn(type = "ENUMERATED", extensible = false, lb = "0", ub = "1")]
 pub struct GUAMIType(pub u8);
 impl GUAMIType {
     pub const NATIVE: u8 = 0u8;
@@ -70,10 +70,12 @@ pub struct UplinkUEAssociatedLPPaTransportprotocolIEsItem {
     sz_lb = "1",
     sz_ub = "256"
 )]
-pub struct UplinkUEAssociatedLPPaTransportprotocolList(pub Vec<UplinkUEAssociatedLPPaTransportprotocolItem>);
+pub struct UplinkUEAssociatedLPPaTransportprotocolList(
+    pub Vec<UplinkUEAssociatedLPPaTransportprotocolItem>,
+);
 
 #[derive(Debug, AperCodec, UperCodec, Eq, PartialEq)]
-#[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
+#[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct UplinkUEAssociatedLPPaTransportprotocolItem {
     #[asn(optional_idx = 0)]
     pub ie_extensions: Option<UplinkUEAssociatedLPPaTransportprotocolIEsItem>,
@@ -85,9 +87,9 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use asn1_codecs::aper::AperCodec;
     use asn1_codecs::PerCodecData;
-    use super::*;
 
     /// Test whether encoding and then decoding a list of optional extensions that include an open
     /// enumeration type results in the same object.
@@ -96,31 +98,34 @@ mod tests {
     /// #[126](https://github.com/ystero-dev/hampi/issues/126).
     #[test]
     fn test_encode_decode_open_type() {
-        let original_test_value = UplinkUEAssociatedLPPaTransportprotocolList(vec![UplinkUEAssociatedLPPaTransportprotocolItem {
-            ie_extensions: Some(
-                UplinkUEAssociatedLPPaTransportprotocolIEsItem {
+        let original_test_value = UplinkUEAssociatedLPPaTransportprotocolList(vec![
+            UplinkUEAssociatedLPPaTransportprotocolItem {
+                ie_extensions: Some(UplinkUEAssociatedLPPaTransportprotocolIEsItem {
                     id: ProtocolIE_ID(176),
                     criticality: Criticality(0),
                     value: UplinkUEAssociatedLPPaTransportprotocolIEsItemvalue::Id_GUAMIType(
-                        GUAMIType(0)
+                        GUAMIType(0),
                     ),
-                }
-            ),
-        }, UplinkUEAssociatedLPPaTransportprotocolItem {
-            ie_extensions: Some(
-                UplinkUEAssociatedLPPaTransportprotocolIEsItem {
+                }),
+            },
+            UplinkUEAssociatedLPPaTransportprotocolItem {
+                ie_extensions: Some(UplinkUEAssociatedLPPaTransportprotocolIEsItem {
                     id: ProtocolIE_ID(176),
                     criticality: Criticality(0),
                     value: UplinkUEAssociatedLPPaTransportprotocolIEsItemvalue::Id_GUAMIType(
-                        GUAMIType(0)
+                        GUAMIType(0),
                     ),
-                }
-            ),
-        }]);
+                }),
+            },
+        ]);
         let mut test_value_encoded = PerCodecData::new_aper();
-        original_test_value.aper_encode(&mut test_value_encoded).unwrap();
+        original_test_value
+            .aper_encode(&mut test_value_encoded)
+            .unwrap();
 
-        let test_value_decoded = UplinkUEAssociatedLPPaTransportprotocolList::aper_decode(&mut test_value_encoded).unwrap();
+        let test_value_decoded =
+            UplinkUEAssociatedLPPaTransportprotocolList::aper_decode(&mut test_value_encoded)
+                .unwrap();
         assert_eq!(original_test_value, test_value_decoded);
     }
 }

--- a/examples/tests/17-rrc.rs
+++ b/examples/tests/17-rrc.rs
@@ -13,6 +13,11 @@ fn main() {
         hex::decode("68CC42821989C402240F3F6BC2D03EA18C80840C22611D0E098FD080814B62E0").unwrap();
     let mut sib1_codec_data = PerCodecData::from_slice_uper(&raw_sib1);
     let sib1 = rrc::BCCH_DL_SCH_Message::uper_decode(&mut sib1_codec_data);
+    eprintln!("sib1: {:#?}", sib1.unwrap());
+
+    let mut raw_sib1 = hex::decode("201bbfa806018001400e880110800a409fe2c20a409de2c404748a82620044200c0118443123213086d70578572c2698ac4b45031000200643002a2081989010ba17a389800060300a84c058310002728134000000000ffffffff650d02b1d6143000488201600").unwrap();
+    let mut sib1_codec_data = PerCodecData::from_slice_uper(&raw_sib1);
+    let sib1 = rrc::DL_DCCH_Message::uper_decode(&mut sib1_codec_data);
 
     eprintln!("sib1: {:#?}", sib1.unwrap());
 }


### PR DESCRIPTION
This fix adds support for advancing the decoder skipping the extension additions, so that the structures can be decoded fully.

Note: This is not a full sequence extension codec support, but at-least on the decode path, everything other than extensions should be decoded properly and thus can be used.