### PR TITLE
Add possibility to disable rustfmt for ASN1 compiler via CLI

### DIFF
--- a/asn-compiler/src/bin/hampi-rs-asn1c.rs
+++ b/asn-compiler/src/bin/hampi-rs-asn1c.rs
@@ -46,6 +46,10 @@ struct Cli {
     /// Log verbosity (default: info, -d: debug, -dd...: trace)
     #[arg(short, action=clap::ArgAction::Count)]
     debug: u8,
+
+    /// Whether to disable `rustfmt` formatting of the generated files.
+    #[arg(long, default_value_t = false)]
+    no_rustfmt: bool,
 }
 
 fn main() -> Result<()> {
@@ -90,6 +94,11 @@ fn main() -> Result<()> {
         cli.codec.clone(),
         derives.clone(),
     );
+
+    if cli.no_rustfmt {
+        compiler.set_rustfmt_generated_code(false);
+    }
+
     compiler.compile_files(&cli.files)?;
 
     Ok(())


### PR DESCRIPTION
As requested [here](https://github.com/ystero-dev/hampi/pull/138#pullrequestreview-3103610101), the feature added in [this MR](https://github.com/ystero-dev/hampi/pull/138) did not include a command line flag for the CLI tool. This MR adds a command line flag and disables `rustfmt` on request.